### PR TITLE
fix(scale): Make scale work properly

### DIFF
--- a/win2xcur/scale.py
+++ b/win2xcur/scale.py
@@ -10,3 +10,7 @@ def apply_to_frames(frames: List[CursorFrame], *, scale: float) -> None:
                 int(round(cursor.image.width * scale)),
                 int(round(cursor.image.height) * scale),
             )
+            cursor.nominal = int(cursor.nominal * scale)
+            hx,hy = cursor.hotspot
+            cursor.hotspot = (int(hx * scale),int(hy*scale))
+


### PR DESCRIPTION
I discovered that the `--scale` command line parameter doesn't work properly when using win2xcur.

I have fixed this issue. 

While I'm not an expert in this field, the code I'm submitting works correctly on my machine.