### PR TITLE
[x2wincur] Add option to align image dimensions to default sizes

### DIFF
--- a/win2xcur/align.py
+++ b/win2xcur/align.py
@@ -1,0 +1,19 @@
+from typing import List
+import bisect
+
+from wand.color import Color
+
+from win2xcur.cursor import CursorFrame
+
+def apply_to_frames(frames: List[CursorFrame]) -> None:
+    sizes = [32, 48, 64, 96, 128, 256]
+    
+    for frame in frames:
+        for cursor in frame:
+            size_index = bisect.bisect_left(sizes, cursor.image.width)
+
+            if size_index < len(sizes):
+                next_size = sizes[size_index]
+                cursor.image.background_color = Color("transparent")
+                cursor.image.extent(width=next_size, height=next_size)
+

--- a/win2xcur/main/x2wincur.py
+++ b/win2xcur/main/x2wincur.py
@@ -8,6 +8,7 @@ from threading import Lock
 from typing import BinaryIO
 
 from win2xcur import scale
+from win2xcur import align
 from win2xcur.parser import open_blob
 from win2xcur.writer import to_smart
 
@@ -20,6 +21,8 @@ def main() -> None:
                         help='Directory to store converted cursor files.')
     parser.add_argument('-S', '--scale', default=None, type=float,
                         help='Scale the cursor by the specified factor.')
+    parser.add_argument('--align-sizes', action='store_true',
+                        help='Align image sizes to Windows default cursor sizes.')
 
     args = parser.parse_args()
     print_lock = Lock()
@@ -36,6 +39,8 @@ def main() -> None:
         else:
             if args.scale:
                 scale.apply_to_frames(cursor.frames, scale=args.scale)
+            if args.align_sizes:
+                align.apply_to_frames(cursor.frames)
             ext, result = to_smart(cursor.frames)
             output = os.path.join(args.output, os.path.basename(name) + ext)
             with open(output, 'wb') as f:

--- a/win2xcur/main/x2wincurtheme.py
+++ b/win2xcur/main/x2wincurtheme.py
@@ -5,7 +5,7 @@ from multiprocessing import cpu_count
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
 
-from win2xcur import scale
+from win2xcur import align, scale
 from win2xcur.parser.xtheme import parse_xcursor_theme
 from win2xcur.theme import ALL_CURSORS
 from win2xcur.writer.inf import export_windows_theme
@@ -19,6 +19,8 @@ def main() -> None:
                         help='Directory to store converted cursor files and install.inf.')
     parser.add_argument('-S', '--scale', default=None, type=float,
                         help='Scale the cursor by the specified factor.')
+    parser.add_argument('--align-sizes', action='store_true',
+                        help='Align image sizes to Windows default cursor sizes.')
 
     args = parser.parse_args()
 
@@ -32,8 +34,14 @@ def main() -> None:
 
     def process(name: str) -> None:
         cursor = getattr(theme, name)
-        if args.scale and cursor:
+
+        if not cursor: 
+            return
+        
+        if args.scale:
             scale.apply_to_frames(cursor.frames, scale=args.scale)
+        if args.align_sizes:
+            align.apply_to_frames(cursor.frames)
 
     with ThreadPool(cpu_count()) as pool:
         pool.map(process, ALL_CURSORS)


### PR DESCRIPTION
Adds an option `--align-sizes` to x2wincur to align image sizes to the next value from 32, 48, 64, 96, 128 and 256, this is is to avoid Windows stretching the cursor up when smaller than 32x, not sure about the behavior for sizes above 32 but it's better to also align to the sizes the Windows default Aero cursors use.

Closes #37