### PR TITLE
inf writer: Use HKCU registry path instead of HKLM

### DIFF
--- a/win2xcur/writer/inf.py
+++ b/win2xcur/writer/inf.py
@@ -18,7 +18,7 @@ AddReg    = Scheme.Reg
 Scheme.Cur = 10,"%CUR_DIR%"
 
 [Scheme.Reg]
-HKLM,"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Control Panel\\Cursors\\Schemes","%SCHEME_NAME%",,"{list}"
+HKCU,"Control Panel\\Cursors\\Schemes","%SCHEME_NAME%",,"{list}"
 
 [Scheme.Cur]
 {files}


### PR DESCRIPTION
This makes the installed theme uninstallable by the user directly in pointers dialog.

Downstream bug report: https://github.com/Tech-Tac/aosp-cursors/issues/1